### PR TITLE
Fixed Error with requirements.txt not being used by Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,5 +32,8 @@ Dockerfile
 README.md
 *.txt
 
+# Allow requirements.txt
+!requirements.txt
+
 # Ignore node_modules if using any frontend libraries
 node_modules/


### PR DESCRIPTION
Allowed requirements.txt in .dockerignore
